### PR TITLE
Make it compatible with ESA v3

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -1,22 +1,31 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
+import { computed } from "@ember/object"
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 export default Mixin.create(DataAdapterMixin, {
   session: service(),
 
-  authorize (xhr) {
-    const {
-      accessToken,
-      client,
-      expiry,
-      tokenType,
-      uid,
-    } = this.get('session.data.authenticated');
-    xhr.setRequestHeader('access-token', accessToken);
-    xhr.setRequestHeader('client', client);
-    xhr.setRequestHeader('expiry', expiry);
-    xhr.setRequestHeader('token-type', tokenType);
-    xhr.setRequestHeader('uid', uid);
+  // Ember-simple-auth version < 3
+  authorize(xhr) {
+    const headers = this.get("headers");
+    Object.entries(headers).map(
+      header => xhr.setRequestHeader(...header)
+    )
   },
+
+  // Ember-simple-auth version >= 3
+  headers: computed("session.data.authenticated.token", function () {
+    const { accessToken, client, expiry, tokenType, uid } = this.get(
+      "session.data.authenticated",
+    );
+
+    return {
+      "access-token": accessToken,
+      "client": client,
+      "expiry": expiry,
+      "token-type": tokenType,
+      "uid": uid,
+    };
+  }),
 });


### PR DESCRIPTION
`authorize` method is no more used in ESAv3

Instead, it uses the `header` computed property

http://ember-simple-auth.com/api/classes/DataAdapterMixin.html

Here is a version where everybody is happy and it works in all cases